### PR TITLE
Fix build failure of SPL because libc-dev is missing (LP: #1536299)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Vcs-Browser: https://github.com/dajhorn/pkg-spl/
 
 Package: spl-dkms
 Architecture: all
-Depends: ${misc:Depends}, dkms (>= 2.2.0.2), lsb-release
+Depends: ${misc:Depends}, libc-dev, dkms (>= 2.2.0.2), lsb-release
 Recommends: spl
 Description: Solaris Porting Layer kernel modules for Linux
  The Solaris Porting Layer (SPL) is a Linux kernel module which provides many of


### PR DESCRIPTION
DKMS SPL build failure occurs on a clean machine because the configure
script attempts to build a small test C program which fails to link
because libc-dev is not installed at that point even though gcc is
installed.

configure: error:
        **\* Please make sure the kmod spl devel <kernel> package for your
        **\* distribution is installed then try again.  If that fails you
        **\* can specify the location of the spl objects with the
        **\* '--with-spl-obj=PATH' option.

The most straight forward fix is to state that libc-dev is a dependency
so that it is installed first before SPL is built.  Most DKMS builds
just require gcc and build directly against the kernel, but for SPL
we have this pre-build configure step which needs libc-dev.

Signed-off-by: Colin Ian King colin.king@canonical.com
