### PR TITLE
copy spl headers before build directory removal

### DIFF
--- a/debian/spl-dkms.dkms
+++ b/debian/spl-dkms.dkms
@@ -14,7 +14,7 @@ PRE_BUILD="configure
 		fi)
   --with-linux-obj=${kernel_source_dir}
 "
-POST_INSTALL="cp
+POST_BUILD="cp
   ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/spl_config.h
   ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/module/Module.symvers
   ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/${kernelver}/${arch}/


### PR DESCRIPTION
DKMS version in sid, clean the build directory before POST_INSTALL is runned

This change copy the files before build directory have been cleaned.
